### PR TITLE
converted what was client-side api routes to NextJS's serverless routes…

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -13,7 +13,7 @@ const Header = () => {
 
   const onSubmit = ({ linkURL, region }) => {
     const listName = linkURL.split('.com/lists/')[1];
-    window.location = `/${region}/${listName}`;
+    window.location = `/search/${region}/${listName}`;
   };
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -798,6 +798,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -2700,6 +2705,14 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "swr": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.5.6.tgz",
+      "integrity": "sha512-Bmx3L4geMZjYT5S2Z6EE6/5Cx6v1Ka0LhqZKq8d6WL2eu9y6gHWz3dUzfIK/ymZVHVfwT/EweFXiYGgfifei3w==",
+      "requires": {
+        "dequal": "2.0.2"
       }
     },
     "tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.6.7",
+    "swr": "^0.5.6",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/pages/api/scraping.js
+++ b/pages/api/scraping.js
@@ -7,8 +7,7 @@ axios.defaults.httpsAgent = new https.Agent({ keepAlive: true });
 
 // Request webpage of icheckmovies list
 export const getMovieList = async (checklistURL) => {
-  const proxy = 'https://morning-dusk-29674.herokuapp.com/'; // Personal Cors-Anywhere proxy server
-  const html = await axios.get(proxy + checklistURL);
+  const html = await axios.get(checklistURL);
   return html;
 };
 
@@ -53,3 +52,10 @@ export const populateMovieList = (html) => {
     list: allMovies,
   };
 };
+
+export default async function handler(req, res) {
+  const html = await getMovieList(req.body.url);
+  const movieList = populateMovieList(html);
+
+  res.status(200).json(movieList);
+}

--- a/pages/api/streaming.js
+++ b/pages/api/streaming.js
@@ -69,12 +69,6 @@ export const getProviderDetails = async (id, region) => {
         providerLogoPath: provider.logo_path,
       });
     }
-    if (provider.provider_id === 337) {
-      providerDetails.push({
-        providerName: 'Disney Plus',
-        providerLogoPath: provider.logo_path,
-      });
-    }
     if (provider.provider_id === 103) {
       providerDetails.push({
         providerName: 'All 4',
@@ -103,3 +97,41 @@ export const getProviderDetails = async (id, region) => {
 
   return providerDetails;
 };
+
+const getAllMoviesProviderData = async (listData, region) => {
+  let allMoviesData = [];
+  let index = 0;
+
+  for (const movie of listData.list) {
+    const movieDetails = await getMovieDetails(
+      movie.title,
+      movie.year.toString(),
+      index
+    );
+
+    index += 1;
+
+    try {
+      const providerDetails = await getProviderDetails(movieDetails.id, region);
+      if (providerDetails.length > 0) {
+        allMoviesData.push({
+          ...movieDetails,
+          providerDetails,
+        });
+      }
+    } catch (error) {
+      console.log('Error with movie ' + movie.title);
+      console.log(error);
+    }
+  }
+  return allMoviesData;
+};
+
+export default async function handler(req, res) {
+  const data = await getAllMoviesProviderData(
+    req.body.listData,
+    req.body.region
+  );
+
+  res.status(200).json(data);
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -18,7 +18,7 @@ const HomePage = () => {
 
   const onSubmit = ({ linkURL, region }) => {
     const listName = linkURL.split('.com/lists/')[1];
-    router.push(`/${region}/${listName}`);
+    router.push(`/search/${region}/${listName}`);
   };
 
   const handleModalOpen = () => {


### PR DESCRIPTION
Also reorganised url path of the search page to now be '/search/[...list]' as the previous structure caused a bug where the dynamic routes would pick up the serverless api folder and think anything accessing the route was referring to a page instead of a route.  Not good. Works perfectly now, though.  Yay.