### PR TITLE
moved movie details api call into its own serverless function

### DIFF
--- a/pages/api/moviedetails.js
+++ b/pages/api/moviedetails.js
@@ -1,0 +1,60 @@
+import axios from 'axios';
+import https from 'https';
+
+axios.defaults.timeout = 60000;
+axios.defaults.httpsAgent = new https.Agent({ keepAlive: true });
+
+const config = {
+  headers: {
+    Authorization: `Bearer ${process.env.NEXT_PUBLIC_TMDB_TOKEN}`,
+  },
+  host: 'api.themoviedb.org',
+};
+
+export const getMovieDetails = async (movieTitle, year, number) => {
+  const formattedTitle = movieTitle
+    .toLowerCase()
+    .trim()
+    .split(' - ')
+    .join('+')
+    .split(' ')
+    .join('+')
+    .split(',')
+    .join('')
+    .split(':')
+    .join('')
+    .split('.')
+    .join('')
+    .split('.')
+    .join('')
+    .split('·')
+    .join('')
+    .split("'")
+    .join('')
+    .normalize('NFD') // Normalises accented characters
+    .replace(/[\u0300-\u036f]/g, ''); // for the search string
+
+  const searchUrl = `https://api.themoviedb.org/3/search/movie?query=${formattedTitle}&year=${year}`;
+
+  const { data } = await axios.get(searchUrl, config);
+
+  let movieData = {
+    listNumber: number + 1,
+    id: data.results[0].id.toString(),
+    title: data.results[0].title,
+    year,
+    imagePath: data.results[0].poster_path,
+  };
+
+  return movieData;
+};
+
+export default async function handler(req, res) {
+  const data = await getMovieDetails(
+    req.body.title,
+    req.body.year,
+    req.body.index
+  );
+
+  res.status(200).json(data);
+}

--- a/pages/api/streaming.js
+++ b/pages/api/streaming.js
@@ -11,44 +11,6 @@ const config = {
   host: 'api.themoviedb.org',
 };
 
-export const getMovieDetails = async (movieTitle, year, number) => {
-  const formattedTitle = movieTitle
-    .toLowerCase()
-    .trim()
-    .split(' - ')
-    .join('+')
-    .split(' ')
-    .join('+')
-    .split(',')
-    .join('')
-    .split(':')
-    .join('')
-    .split('.')
-    .join('')
-    .split('.')
-    .join('')
-    .split('·')
-    .join('')
-    .split("'")
-    .join('')
-    .normalize('NFD') // Normalises accented characters
-    .replace(/[\u0300-\u036f]/g, ''); // for the search string
-
-  const searchUrl = `https://api.themoviedb.org/3/search/movie?query=${formattedTitle}&year=${year}`;
-
-  const { data } = await axios.get(searchUrl, config);
-
-  let movieData = {
-    listNumber: number + 1,
-    id: data.results[0].id.toString(),
-    title: data.results[0].title,
-    year,
-    imagePath: data.results[0].poster_path,
-  };
-
-  return movieData;
-};
-
 export const getProviderDetails = async (id, region) => {
   const providerUrl = `https://api.themoviedb.org/3/movie/${id}/watch/providers`;
 
@@ -98,40 +60,8 @@ export const getProviderDetails = async (id, region) => {
   return providerDetails;
 };
 
-const getAllMoviesProviderData = async (listData, region) => {
-  let allMoviesData = [];
-  let index = 0;
-
-  for (const movie of listData.list) {
-    const movieDetails = await getMovieDetails(
-      movie.title,
-      movie.year.toString(),
-      index
-    );
-
-    index += 1;
-
-    try {
-      const providerDetails = await getProviderDetails(movieDetails.id, region);
-      if (providerDetails.length > 0) {
-        allMoviesData.push({
-          ...movieDetails,
-          providerDetails,
-        });
-      }
-    } catch (error) {
-      console.log('Error with movie ' + movie.title);
-      console.log(error);
-    }
-  }
-  return allMoviesData;
-};
-
 export default async function handler(req, res) {
-  const data = await getAllMoviesProviderData(
-    req.body.listData,
-    req.body.region
-  );
+  const data = await getProviderDetails(req.body.id, req.body.region);
 
   res.status(200).json(data);
 }

--- a/pages/search/[...list].js
+++ b/pages/search/[...list].js
@@ -22,6 +22,39 @@ const ResultsPage = () => {
 
   const { list } = router.query;
 
+  const getAllMoviesProviderData = async (listData, region) => {
+    let allMoviesData = [];
+    let index = 0;
+
+    for (const movie of listData.list) {
+      const { data: movieDetails } = await axios.post('/api/moviedetails', {
+        title: movie.title,
+        year: movie.year.toString(),
+        index,
+      });
+
+      index += 1;
+
+      try {
+        const { data: providerDetails } = await axios.post('/api/streaming', {
+          id: movieDetails.id,
+          region,
+        });
+
+        if (providerDetails.length > 0) {
+          allMoviesData.push({
+            ...movieDetails,
+            providerDetails,
+          });
+        }
+      } catch (error) {
+        console.log('Error with movie ' + movie.title);
+        console.log(error);
+      }
+    }
+    return allMoviesData;
+  };
+
   const getListData = async () => {
     const region = list[0].toUpperCase();
     setListRegion(region);
@@ -41,10 +74,7 @@ const ResultsPage = () => {
 
       setAllMoviesListTitle(listData.listTitle);
 
-      const { data: allMoviesData } = await axios.post('/api/streaming', {
-        listData,
-        region,
-      });
+      const allMoviesData = await getAllMoviesProviderData(listData, region);
 
       await dispatch({
         type: 'ADD_MOVIES',


### PR DESCRIPTION
I did this for two reasons.

1.  It makes everything easier to read, as it's better organised.
2.  Vercel has a limit of 30 seconds on getting a response back from a serverless function.  In the previous version, the for...of loop that made all the calls was its own serverless function, but this meant that it could take more than 30 seconds for it to return a response if the list was longer than 100 entries to loop through and check.  I moved the loop logic back to the search page, and instead only had each individual call be a serverless function, each called from within that loop, resolving this potential issue.